### PR TITLE
Fix Conda CI environment and add API smoke tests

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,34 +1,36 @@
 name: Python Package using Conda
 
-on: [push]
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   build-linux:
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 5
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.10'
-    - name: Add conda to system path
-      run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
-    - name: Install dependencies
-      run: |
-        conda env update --file environment.yml --name base
-    - name: Lint with flake8
-      run: |
-        conda install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        conda install pytest
-        pytest
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Add Conda to system path
+        run: echo "$CONDA/bin" >> "$GITHUB_PATH"
+
+      - name: Install dependencies
+        run: conda env update --file environment.yml --name base
+
+      - name: Lint with flake8
+        run: |
+          # Stop the build for Python syntax errors and undefined names.
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # Report style and complexity issues without failing the build.
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+      - name: Test with pytest
+        run: pytest -q

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -14,23 +14,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-
-      - name: Add Conda to system path
-        run: echo "$CONDA/bin" >> "$GITHUB_PATH"
-
       - name: Install dependencies
         run: conda env update --file environment.yml --name base
 
       - name: Lint with flake8
         run: |
           # Stop the build for Python syntax errors and undefined names.
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          conda run --name base flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # Report style and complexity issues without failing the build.
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          conda run --name base flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
       - name: Test with pytest
-        run: pytest -q
+        run: conda run --name base python -m pytest -q

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,10 @@
 name: base
 channels:
   - defaults
-  - conda-forge
 dependencies:
   - python=3.10
-  - pytest
-  - flake8
+  - pip
+  - pip:
+      - -r requirements.txt
+      - flake8>=6,<8
+      - pytest>=7,<9

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,44 @@
+import pytest
+
+import app as app_module
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setattr(app_module, "AUDIO_DIR", tmp_path)
+    app_module.app.config.update(TESTING=True)
+
+    with app_module.app.test_client() as test_client:
+        yield test_client
+
+
+def test_list_voices(client):
+    response = client.get("/api/tts/voices")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["voices"]
+    assert {"id", "name", "language", "description"} <= payload["voices"][0].keys()
+
+
+def test_generate_requires_text(client):
+    response = client.post("/api/tts/generate", json={})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "Text is required."}
+
+
+def test_generate_and_serve_audio(client):
+    response = client.post(
+        "/api/tts/generate",
+        json={"text": "Newwave CI smoke test.", "voice": "narrator_en"},
+    )
+
+    assert response.status_code == 200
+    metadata = response.get_json()["metadata"]
+    assert metadata["format"] == "wav"
+    assert metadata["duration_seconds"] > 0
+
+    audio_response = client.get(metadata["url"])
+    assert audio_response.status_code == 200
+    assert audio_response.data.startswith(b"RIFF")


### PR DESCRIPTION
## Summary

- repair the failing Conda workflow with a complete root-level `environment.yml`
- install Flask from `requirements.txt` together with pytest and flake8
- run lint and tests explicitly inside Conda's `base` environment
- add smoke tests for voice discovery, input validation, and WAV generation/serving

## Root cause

The original workflow required `environment.yml`, but the checked-out repository did not provide a usable dependency environment. Once that was repaired, the first PR run exposed a Python-path mismatch: `pytest` was being launched outside the Conda interpreter and could not import the root `app.py`.

## Validation

GitHub Actions run **#12** passed:

- Conda environment update: passed
- fatal-error flake8 check: passed
- API test suite: **3 passed**
