### PR TITLE
Add VO-1 SPIDER-0 telemetry foundation

### DIFF
--- a/docs/README-VO1.md
+++ b/docs/README-VO1.md
@@ -1,0 +1,31 @@
+# VO-1 / SPIDER-0 Repository Foundation
+
+This tree establishes the software-side foundation for the VO-1 digital twin telemetry stack.
+
+## Authority
+
+- `docs/telemetry/SPIDER-0-SPEC-002.md` — governing wire-protocol specification as received.
+- The digital twin remains authoritative for simulation pass/fail.
+- Telemetry and HMI code are display/transport layers and must not override simulation authority.
+- No file in this tree authorizes physical fabrication or radio deployment.
+
+## Structure
+
+```text
+vo1/
+├── hmi/                         # React/Tailwind operator interface contract
+├── protocol/                    # SPIDER-0 wire types, constants, validation
+├── telemetry/                   # runtime decoding/normalization boundary
+├── tests/                       # protocol/conformance tests and golden vectors
+└── schemas/                     # machine-readable protocol contracts
+
+docs/
+├── telemetry/                   # accepted protocol specifications
+├── hmi/                         # HMI sign/state language and component map
+├── simulation/                  # simulation plans and result contracts
+└── deployment/                  # deployment charter and authority gates
+```
+
+## Important conformance note
+
+The supplied SPIDER-0 document contains example wire bytes that should not yet be treated as an RFC 8949 deterministic-CBOR golden vector. RFC 8949 deterministic map ordering is applied by encoded-key length and then bytewise value. The supplied prose/hex uses a different field ordering, and the stated `payload_len` should be independently verified. This repository therefore records the received specification while keeping executable golden-vector acceptance explicitly pending conformance review.

--- a/docs/deployment/VO1-CHARTER-001.md
+++ b/docs/deployment/VO1-CHARTER-001.md
@@ -1,0 +1,37 @@
+# VO1-CHARTER-001 v0.1 — Sovereign Deployment Charter
+
+**Status:** Draft / non-authorizing.
+
+## Authority hierarchy
+
+1. Digital twin simulation authority.
+2. Approved engineering specifications and schemas.
+3. Telemetry transport and validation layer.
+4. HMI presentation layer.
+
+A lower layer cannot override a higher layer's result.
+
+## Deployment boundary
+
+This charter defines software governance only. It does not authorize fabrication, procurement, radio activation, field deployment, or energization.
+
+## Data custody
+
+- Telemetry is accepted only after protocol validation.
+- Node identity and public-key resolution are deployment-controlled.
+- Signature failures, replayed sequences, and timestamp-skewed frames are rejected or quarantined according to the receiver policy.
+- Simulation results are immutable from the HMI.
+
+## Freeze requirements
+
+Before any physical deployment decision, the project must separately approve:
+
+- CBOR conformance vectors.
+- Cryptographic signing/verification tests.
+- Digital-twin simulation gates.
+- Electrical/thermal/structural reviews.
+- Field safety and deployment procedures.
+
+## Current status
+
+SPIDER-0 is software specification only. Physical radio and firmware remain unauthorized.

--- a/docs/hmi/VO1-UI-002-Dashboard-Component-Map.md
+++ b/docs/hmi/VO1-UI-002-Dashboard-Component-Map.md
@@ -1,0 +1,27 @@
+# VO1-UI-002 Dashboard Component Map
+
+The dashboard is a read-only presentation layer over the SPIDER-0 decoder and digital-twin result contracts.
+
+| Component | Source | Primary state |
+|---|---|---|
+| Structure / Level 0 | geometry status | zinc / green |
+| Level 1 Structural FEA | simulation result | green / amber / red |
+| Level 2 Solar Optical Yield | simulation result | green / amber |
+| Level 3 Thermal / CFD | simulation result | green / amber / red |
+| Level 4 Power / Battery | SPIDER-0 telemetry | green / amber / red |
+| Field Repair / Part QR | asset registry | sky / zinc |
+| Sovereign Deployment Charter | charter status | zinc / amber |
+| Communications | SPIDER-0 presence | sky |
+| Fault feed | TELE-012 | amber / red |
+
+## HMI state tokens
+
+- Green = nominal / energy-positive
+- Amber = attention / reduced margin
+- Red = fault / protective action
+- Blue = telemetry / communications activity
+- Zinc = structural or informational state
+
+## Authority rule
+
+No UI action may mutate a simulation pass/fail result or fabricate a telemetry value. Operator controls may request actions only through an explicitly authorized future command interface; this repository currently defines telemetry as read-only.

--- a/docs/simulation/L3-CFD-001.md
+++ b/docs/simulation/L3-CFD-001.md
@@ -1,0 +1,30 @@
+# L3-CFD-001 v0.1 — Thermal / CFD Simulation Plan
+
+**Status:** Planning artifact only. No fabrication authorization.
+
+## Objective
+
+Evaluate thermal behavior of the VO-1 digital twin under nominal, conservation, survival, and fault-boundary operating conditions. Results must remain read-only inputs to the HMI.
+
+## Required cases
+
+1. Nominal ambient / nominal load.
+2. High ambient / peak PV input.
+3. Low ambient / battery heating requirement.
+4. High internal humidity / condensation-risk boundary.
+5. Battery thermal boundary approaching TELE-012 bit 0.
+6. Habitat temperature boundary approaching TELE-012 bit 6.
+7. Power-overload boundary corresponding to TELE-012 bit 8.
+
+## Outputs
+
+- Temperature field and maxima/minima.
+- Heat flux paths.
+- Boundary-condition assumptions.
+- Convergence/error metrics.
+- Pass/fail table tied to the digital-twin authority record.
+- Telemetry observables suitable for later SPIDER-0 mapping.
+
+## Gate
+
+No physical implementation is implied by this plan. Simulation results must be reviewed and frozen before they are treated as an HMI reference artifact.

--- a/docs/telemetry/SPIDER-0-SPEC-002.md
+++ b/docs/telemetry/SPIDER-0-SPEC-002.md
@@ -1,0 +1,92 @@
+# SPIDER-0-SPEC-002 v0.1
+
+**Document ID:** SPIDER-0-SPEC-002 v0.1  
+**Parent:** SPIDER-0-SCHEMA-001-CDDL v0.1 / VO-1 SRD v1.0  
+**Layer:** Layer 3 — Signs / HMI & Telemetry  
+**Status:** Accepted baseline; wire format frozen pending conformance testing  
+**Physical authorization:** None
+
+## Purpose
+
+SPIDER-0 defines the deterministic telemetry fabric between a VO-1 station, field gateways, the digital twin, and the operator HMI.
+
+### Wire baseline
+
+- Deterministic CBOR, RFC 8949 §4.2.
+- Integer-only fixed-point sensor representation.
+- Ed25519 signatures with VO-1 context separation `SPIDER-0-V01-AUTH`.
+- Monotonic sequence replay gate.
+- ±120 second timestamp drift gate, with quarantine for skewed frames.
+- Adaptive telemetry cadence based on operational mode.
+- TELE-012 16-bit fault register.
+
+## Message classes
+
+| Type | Name | Purpose |
+|---:|---|---|
+| `0x01` | Telemetry | Periodic instantaneous sensor vector |
+| `0x02` | Presence | Heartbeat / route presence |
+| `0x03` | Event | Immediate fault or priority event |
+| `0x04` | Cluster Presence | Aggregated multi-node presence |
+
+## Telemetry payload keys
+
+| Key | Field | Encoding |
+|---:|---|---|
+| 1 | Internal temperature | °C × 10 |
+| 2 | External temperature | °C × 10 |
+| 3 | Internal humidity | % RH |
+| 4 | Battery SoC | % |
+| 5 | PV input power | W |
+| 6 | PV daily yield | Wh |
+| 7 | System load | W |
+| 8 | Battery temperature | °C × 10 |
+| 9 | Canopy latch | `0/1` |
+| 10 | Ground anchoring | `0/1` |
+| 11 | Communications link | enum |
+| 12 | TELE-012 faults | uint16 |
+| 13 | HMI primary state | enum |
+
+## Operational cadence
+
+| Mode | HMI | Telemetry | Heartbeat |
+|---:|---|---:|---:|
+| 0 Normal | Green | 60 s | 300 s |
+| 1 Conservation | Amber | 300 s | 900 s |
+| 2 Survival | Amber | 900 s | 1800 s |
+| 3 Emergency | Red | Immediate | 30 s continuous |
+
+Priority-0 edge events preempt scheduled telemetry.
+
+## Cryptographic boundary
+
+The signing input is:
+
+```text
+ASCII("SPIDER-0-V01-AUTH") || SHA-256(canonical-envelope-without-signature)
+```
+
+The signature is a detached 64-byte Ed25519 signature. Public-key resolution is external to the wire format and must use the node identity/certificate authority defined by the deployment environment.
+
+## Replay / time gates
+
+A receiver accepts a frame only when its sequence is strictly greater than the highest accepted sequence for that node. A timestamp outside the configured ±120 s window is quarantined rather than silently accepted.
+
+## TELE-012 fault register
+
+Bits 0–9 are assigned; bits 10–15 are reserved and must remain zero.
+
+- 0 Battery overtemperature
+- 1 Battery undertemperature
+- 2 PV zero in daylight
+- 3 Canopy unlatched
+- 4 Anchor displaced
+- 5 Communications lost
+- 6 Habitat temperature unsafe
+- 7 Condensation risk
+- 8 Power overload
+- 9 Emergency disconnect
+
+## Conformance status
+
+The received diagnostic examples are stored as **source examples**, not yet as accepted canonical golden vectors. Independent encoding/decoding tests must establish the exact canonical bytes before firmware or hardware implementation treats them as normative.

--- a/vo1/protocol/constants.js
+++ b/vo1/protocol/constants.js
@@ -1,0 +1,68 @@
+export const SPIDER0_MAGIC = 0x5350;
+export const SPIDER0_VERSION = 1;
+export const SIGNING_CONTEXT = 'SPIDER-0-V01-AUTH';
+export const TIMESTAMP_DRIFT_SECONDS = 120;
+
+export const MessageType = Object.freeze({
+  TELEMETRY: 0x01,
+  PRESENCE: 0x02,
+  EVENT: 0x03,
+  CLUSTER_PRESENCE: 0x04,
+});
+
+export const HmiState = Object.freeze({
+  GREEN: 0,
+  AMBER: 1,
+  RED: 2,
+});
+
+export const OperatingMode = Object.freeze({
+  NORMAL: 0,
+  CONSERVATION: 1,
+  SURVIVAL: 2,
+  EMERGENCY: 3,
+});
+
+export const CadenceSeconds = Object.freeze({
+  [OperatingMode.NORMAL]: { telemetry: 60, heartbeat: 300 },
+  [OperatingMode.CONSERVATION]: { telemetry: 300, heartbeat: 900 },
+  [OperatingMode.SURVIVAL]: { telemetry: 900, heartbeat: 1800 },
+  [OperatingMode.EMERGENCY]: { telemetry: 0, heartbeat: 30 },
+});
+
+export const FaultBit = Object.freeze({
+  BATT_OVERTEMP: 0,
+  BATT_UNDERTEMP: 1,
+  PV_ZERO_DAYLIGHT: 2,
+  CANOPY_UNLATCHED: 3,
+  ANCHOR_DISPLACED: 4,
+  COMMS_LOST: 5,
+  TEMP_HAB_UNSAFE: 6,
+  CONDENSATION_RISK: 7,
+  POWER_OVERLOAD: 8,
+  EMERGENCY_DISCON: 9,
+});
+
+export const RESERVED_FAULT_MASK = 0xfc00;
+export const SIGNATURE_BYTES = 64;
+
+export function assertFaultRegister(faults) {
+  if (!Number.isInteger(faults) || faults < 0 || faults > 0xffff) {
+    throw new RangeError('TELE-012 must be uint16');
+  }
+  if ((faults & RESERVED_FAULT_MASK) !== 0) {
+    throw new Error('TELE-012 reserved bits 10-15 must remain zero');
+  }
+}
+
+export function validateReplay(seq, highestAccepted) {
+  if (!Number.isInteger(seq) || seq < 0) throw new RangeError('seq must be uint');
+  return seq > highestAccepted;
+}
+
+export function validateTimestamp(timestamp, networkTime, drift = TIMESTAMP_DRIFT_SECONDS) {
+  if (!Number.isInteger(timestamp) || !Number.isInteger(networkTime)) {
+    throw new RangeError('timestamps must be integer epoch seconds');
+  }
+  return Math.abs(timestamp - networkTime) <= drift;
+}

--- a/vo1/schemas/SPIDER-0-SCHEMA-001-CDDL.cddl
+++ b/vo1/schemas/SPIDER-0-SCHEMA-001-CDDL.cddl
@@ -1,0 +1,49 @@
+; SPIDER-0-SCHEMA-001-CDDL / implementation-aligned subset
+; Source baseline: SPIDER-0-SPEC-002 v0.1
+
+spider0-envelope = {
+  "magic": uint,
+  "version": uint,
+  "msg_type": uint,
+  "node_id": node-id,
+  "seq": uint,
+  "timestamp": uint,
+  "flags": uint,
+  "payload_len": uint,
+  "payload": payload,
+  ? "signature": signature
+}
+
+node-id = tstr .size (1..64)
+signature = bstr .size 64
+
+payload = telemetry-payload / presence-payload / event-payload / cluster-presence-payload
+
+telemetry-payload = {
+  1: int,
+  2: int,
+  3: uint,
+  4: uint,
+  5: uint,
+  6: uint,
+  7: uint,
+  8: int,
+  9: uint,
+  10: uint,
+  11: uint,
+  12: uint .le 65535,
+  13: uint
+}
+
+presence-payload = { * uint => uint }
+event-payload = { 1: uint, 2: uint, 3: uint, 4: uint, 5: tstr }
+
+cluster-presence-payload = {
+  1: cluster-id,
+  2: uint,
+  3: uint,
+  4: [* node-summary-record]
+}
+
+cluster-id = bstr .size (4..8) / tstr
+node-summary-record = [node-id, uint, uint, int, uint, uint]

--- a/vo1/schemas/spider0-envelope.schema.json
+++ b/vo1/schemas/spider0-envelope.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/vo1/spider0/telemetry-v0.1.json",
+  "title": "SPIDER-0 Telemetry Envelope",
+  "type": "object",
+  "required": ["magic", "version", "msg_type", "node_id", "seq", "timestamp", "flags", "payload_len", "payload"],
+  "properties": {
+    "magic": {"const": 21328},
+    "version": {"const": 1},
+    "msg_type": {"type": "integer", "minimum": 1, "maximum": 4},
+    "node_id": {"type": "string", "minLength": 1, "maxLength": 64},
+    "seq": {"type": "integer", "minimum": 0, "maximum": 4294967295},
+    "timestamp": {"type": "integer", "minimum": 0, "maximum": 18446744073709551615},
+    "flags": {"type": "integer", "minimum": 0, "maximum": 255},
+    "payload_len": {"type": "integer", "minimum": 0, "maximum": 65535},
+    "payload": {"type": "object"},
+    "signature": {"type": "string", "pattern": "^[0-9a-fA-F]{128}$"}
+  }
+}

--- a/vo1/telemetry/decoder.js
+++ b/vo1/telemetry/decoder.js
@@ -1,0 +1,42 @@
+export const telemetryPayloadKeys = Object.freeze({
+  internalTempC10: 1,
+  externalTempC10: 2,
+  internalHumidityPct: 3,
+  batterySocPct: 4,
+  pvInputW: 5,
+  pvDailyWh: 6,
+  systemLoadW: 7,
+  batteryTempC10: 8,
+  canopyLatch: 9,
+  groundAnchoring: 10,
+  commsLink: 11,
+  faults: 12,
+  hmiState: 13,
+});
+
+export function decodeTelemetryPayload(payload) {
+  if (!payload || typeof payload !== 'object') throw new TypeError('payload must be an object');
+  return {
+    internalTempC: payload[1] / 10,
+    externalTempC: payload[2] / 10,
+    internalHumidityPct: payload[3],
+    batterySocPct: payload[4],
+    pvInputW: payload[5],
+    pvDailyWh: payload[6],
+    systemLoadW: payload[7],
+    batteryTempC: payload[8] / 10,
+    canopyLatch: payload[9],
+    groundAnchoring: payload[10],
+    commsLink: payload[11],
+    faults: payload[12],
+    hmiState: payload[13],
+  };
+}
+
+export function toHmiPresentation(telemetry) {
+  const faulted = telemetry.faults !== 0;
+  return {
+    ...telemetry,
+    primaryState: faulted ? 'red' : telemetry.hmiState === 1 ? 'amber' : 'green',
+  };
+}

--- a/vo1/tests/golden/SPIDER-0-V0.1-NOMINAL-SOURCE.json
+++ b/vo1/tests/golden/SPIDER-0-V0.1-NOMINAL-SOURCE.json
@@ -1,0 +1,35 @@
+{
+  "id": "SPIDER-0-V0.1-NOMINAL-SOURCE",
+  "status": "source-example-pending-canonical-validation",
+  "message": {
+    "magic": 21328,
+    "version": 1,
+    "msg_type": 1,
+    "node_id": "VO1-ASY-0001",
+    "seq": 1042,
+    "timestamp": 1786684800,
+    "flags": 2,
+    "payload_len_claimed": 44,
+    "payload": {
+      "1": 215,
+      "2": 142,
+      "3": 48,
+      "4": 92,
+      "5": 340,
+      "6": 980,
+      "7": 42,
+      "8": 240,
+      "9": 1,
+      "10": 1,
+      "11": 2,
+      "12": 0,
+      "13": 0
+    },
+    "signature_hex": "4b8c9f220d91a27e7fa403b21849d74998782a170560b411daea3027b409cdfe89ab2e3401fae620c45167b542031a613589b251390f70a597a13c9e99a8050e"
+  },
+  "acceptance": {
+    "canonical_cbor": false,
+    "signature_verified": false,
+    "reason": "The received example must be independently re-encoded under RFC 8949 deterministic ordering before it can become a golden vector."
+  }
+}

--- a/vo1/tests/protocol-invariants.test.mjs
+++ b/vo1/tests/protocol-invariants.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import {
+  MessageType,
+  HmiState,
+  OperatingMode,
+  assertFaultRegister,
+  validateReplay,
+  validateTimestamp,
+} from '../protocol/constants.js';
+
+assert.equal(MessageType.TELEMETRY, 1);
+assert.equal(MessageType.PRESENCE, 2);
+assert.equal(MessageType.EVENT, 3);
+assert.equal(MessageType.CLUSTER_PRESENCE, 4);
+assert.doesNotThrow(() => assertFaultRegister(0));
+assert.throws(() => assertFaultRegister(0x400));
+assert.equal(validateReplay(1043, 1042), true);
+assert.equal(validateReplay(1042, 1042), false);
+assert.equal(validateTimestamp(1000, 1120), true);
+assert.equal(validateTimestamp(1000, 1121), false);
+assert.equal(HmiState.GREEN, 0);
+assert.equal(HmiState.AMBER, 1);
+assert.equal(HmiState.RED, 2);
+assert.equal(OperatingMode.NORMAL, 0);
+assert.equal(OperatingMode.EMERGENCY, 3);
+console.log('SPIDER-0 protocol invariants: PASS');


### PR DESCRIPTION
## Summary
- add the accepted SPIDER-0-SPEC-002 telemetry baseline
- add CDDL and JSON schema contracts
- add protocol constants, replay/time/fault invariants, and telemetry decoder mapping
- record the supplied nominal diagnostic vector as a pending conformance source example
- add VO1-UI-002 dashboard component map
- add L3-CFD-001 planning artifact
- add VO1-CHARTER-001 draft governance artifact

## Conformance note
The received CBOR example is intentionally not marked as a canonical golden vector yet. The repository records it as a source example because its stated map ordering and payload length require independent RFC 8949 deterministic-CBOR validation before firmware/hardware use.

## Authority boundary
No physical fabrication, radio activation, or deployment is authorized by this change. The digital twin remains authoritative for simulation results, and the HMI/telemetry layer is read-only with respect to simulation pass/fail.